### PR TITLE
Improve performance and type safety

### DIFF
--- a/collection/list.go
+++ b/collection/list.go
@@ -28,8 +28,16 @@ func (list List[T]) ToArray() []T {
 }
 
 func (list List[T]) Distinct() List[T] {
-	set := map[any]types.Empty{}
-	var result List[T]
+	if len(list) == 0 {
+		return nil
+	}
+
+	result := make(List[T], 0, len(list))
+	set := make(map[any]types.Empty, len(list))
+
+	if !reflect.TypeOf(list[0]).Comparable() {
+		panic("collection: Distinct requires list elements to be comparable")
+	}
 
 	for _, item := range list {
 		if _, exists := set[item]; !exists {

--- a/collection/map.go
+++ b/collection/map.go
@@ -10,7 +10,7 @@ import (
 type MutableMap[K comparable, V any] map[K]V
 
 func Map[K, NK comparable, V, NV any](original MutableMap[K, V], fn func(K, V) (NK, NV)) MutableMap[NK, NV] {
-	newMap := map[NK]NV{}
+	newMap := make(map[NK]NV, len(original))
 
 	for key, value := range original {
 		newKey, newValue := fn(key, value)
@@ -21,7 +21,7 @@ func Map[K, NK comparable, V, NV any](original MutableMap[K, V], fn func(K, V) (
 }
 
 func MapKeys[K, NK comparable, V any](original MutableMap[K, V], fn func(K, V) NK) MutableMap[NK, V] {
-	newMap := map[NK]V{}
+	newMap := make(map[NK]V, len(original))
 
 	for key, value := range original {
 		newMap[fn(key, value)] = value
@@ -31,7 +31,7 @@ func MapKeys[K, NK comparable, V any](original MutableMap[K, V], fn func(K, V) N
 }
 
 func MapValues[K comparable, V, NV any](original MutableMap[K, V], fn func(K, V) NV) MutableMap[K, NV] {
-	newMap := map[K]NV{}
+	newMap := make(map[K]NV, len(original))
 
 	for key, value := range original {
 		newMap[key] = fn(key, value)
@@ -41,7 +41,7 @@ func MapValues[K comparable, V, NV any](original MutableMap[K, V], fn func(K, V)
 }
 
 func (m MutableMap[K, V]) Map(fn func(K, V) (any, any)) MutableMap[any, any] {
-	newMap := map[any]any{}
+	newMap := make(map[any]any, len(m))
 
 	for key, value := range m {
 		newKey, newValue := fn(key, value)
@@ -66,7 +66,7 @@ func (m MutableMap[K, V]) ForEach(consumer function.BiConsumer[K, V]) {
 }
 
 func (m MutableMap[K, V]) Filter(predicate function.BiPredicate[K, V]) MutableMap[K, V] {
-	filteredMap := map[K]V{}
+	filteredMap := make(map[K]V, len(m))
 
 	for k, v := range m {
 		if predicate(k, v) {
@@ -106,6 +106,7 @@ func (m MutableMap[K, V]) Copy() MutableMap[K, V] {
 }
 
 func (m MutableMap[K, V]) Keys() (keys List[K]) {
+	keys = make(List[K], 0, len(m))
 	for key := range m {
 		keys = append(keys, key)
 	}
@@ -114,6 +115,7 @@ func (m MutableMap[K, V]) Keys() (keys List[K]) {
 }
 
 func (m MutableMap[K, V]) Values() (values List[V]) {
+	values = make(List[V], 0, len(m))
 	for _, value := range m {
 		values = append(values, value)
 	}
@@ -122,6 +124,7 @@ func (m MutableMap[K, V]) Values() (values List[V]) {
 }
 
 func (m MutableMap[K, V]) Entries() (values []Pair[K, V]) {
+	values = make([]Pair[K, V], 0, len(m))
 	for k, v := range m {
 		values = append(values, PairOf(k, v))
 	}

--- a/collection/pair.go
+++ b/collection/pair.go
@@ -1,23 +1,18 @@
 package collection
 
-type Pair[K comparable, V any] [2]any
+type Pair[K comparable, V any] struct {
+	first  K
+	second V
+}
 
 func PairOf[K comparable, V any](key K, value V) Pair[K, V] {
-	return Pair[K, V]{key, value}
+	return Pair[K, V]{first: key, second: value}
 }
 
 func (p Pair[K, V]) First() K {
-	if first, ok := p[0].(K); ok {
-		return first
-	}
-
-	panic("invalid type of first element")
+	return p.first
 }
 
 func (p Pair[K, V]) Second() V {
-	if second, ok := p[1].(V); ok {
-		return second
-	}
-
-	panic("invalid type of second element")
+	return p.second
 }

--- a/collection/pair_test.go
+++ b/collection/pair_test.go
@@ -21,21 +21,11 @@ func TestPairFirst(t *testing.T) {
 		p := collection.PairOf("key", "value")
 		assert.Equal(t, "key", p.First())
 	})
-
-	t.Run("panics on invalid type", func(t *testing.T) {
-		p := collection.Pair[string, string]{1, "value"}
-		assert.Panics(t, func() { p.First() })
-	})
 }
 
 func TestPairSecond(t *testing.T) {
 	t.Run("gets second element of pair", func(t *testing.T) {
 		p := collection.PairOf("key", "value")
 		assert.Equal(t, "value", p.Second())
-	})
-
-	t.Run("panics on invalid type", func(t *testing.T) {
-		p := collection.Pair[string, int]{"key", "value"}
-		assert.Panics(t, func() { p.Second() })
 	})
 }

--- a/collection/set.go
+++ b/collection/set.go
@@ -56,6 +56,7 @@ func (s Set[K]) String() string {
 }
 
 func (s Set[K]) Values() (values List[K]) {
+	values = make(List[K], 0, len(s))
 	for k := range s {
 		values = append(values, k)
 	}


### PR DESCRIPTION
## Summary
- optimize `Distinct` and guard against non-comparable types
- preallocate maps and lists in map utilities and set values
- replace `Pair` backing array with a typed struct
- update tests for new `Pair` behavior

## Testing
- `go vet ./...`
- `go test ./...`
